### PR TITLE
Updated catalog image size

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -8,6 +8,11 @@ img {
 	/*max-width: 460px;*/
 }
 
+.ac-img_original_display img {
+	width: auto !important;
+	height: auto !important;
+}
+
 .wrapper {
 	overflow: hidden;
 }


### PR DESCRIPTION
Catalog images were being blown up in size, which (in some cases) is not allowed by the agreement with the authors. Image sizes are now set to their default size rather than scaled.